### PR TITLE
Cleanup preapreCrab and add T&P MC scripts

### DIFF
--- a/inputs/dy2017_TnP_v9.txt
+++ b/inputs/dy2017_TnP_v9.txt
@@ -1,0 +1,1 @@
+/DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL17RECO-106X_mc2017_realistic_v6-v3/AODSIM

--- a/inputs/dy2018_TnP_v9.txt
+++ b/inputs/dy2018_TnP_v9.txt
@@ -1,0 +1,1 @@
+/DYJetsToMuMu_H2ErratumFix_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL18RECO-106X_upgrade2018_realistic_v11_L1v1-v3/AODSIM

--- a/scripts/makeNanoV9MC2017TagAndProbe.sh
+++ b/scripts/makeNanoV9MC2017TagAndProbe.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [[ $# -lt 1 ]]; then
+    echo "Requires at least one command line arguments!"
+    echo "ex. "
+    echo "    bash makeNanoV9MCTagAndProbePostVFP <das_path> <name> <nthreads>"
+    exit 1
+fi
+
+sample_name=$1
+if [[ "$sample_name" != file:* ]]; then
+    sample_name=dbs:$sample_name
+fi
+
+nevents=1000
+name=${2}
+nThreads=4
+if [[ $# -gt 2 ]]; then
+    nThreads=${3}
+fi
+if [[ $# -gt 3 ]]; then
+    echo "Secondary files not expected for Nano V9!"
+    exit 1
+fi
+
+config_name=configs/${name}_cfg.py
+outfile=${name}.root
+
+cmsDriver.py RECO --conditions 106X_mc2017_realistic_v10 \
+    --datatier NANOAODSIM --eventcontent NANOAODSIM \
+    --era Run2_2017,run2_nanoAOD_106Xv2 \
+    --geometry DB:Extended \
+    --customise Configuration/DataProcessing/Utils.addMonitoring, PhysicsTools/NanoAOD/nanoTP_cff.customizeNANOTP \
+    --filein $sample_name --fileout file:$outfile --nThreads $nThreads --no_exec \
+    --python_filename $config_name --mc \
+    --scenario pp --step PAT,USERNANO:nanotpSequenceMC \
+    --runUnscheduled -n $nevents 
+

--- a/scripts/makeNanoV9MC2018TagAndProbe.sh
+++ b/scripts/makeNanoV9MC2018TagAndProbe.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+if [[ $# -lt 1 ]]; then
+    echo "Requires at least one command line arguments!"
+    echo "ex. "
+    echo "    bash makeNanoV9MCTagAndProbePostVFP <das_path> <name> <nthreads>"
+    exit 1
+fi
+
+sample_name=$1
+if [[ "$sample_name" != file:* ]]; then
+    sample_name=dbs:$sample_name
+fi
+
+nevents=1000
+name=${2}
+nThreads=4
+if [[ $# -gt 2 ]]; then
+    nThreads=${3}
+fi
+if [[ $# -gt 3 ]]; then
+    echo "Secondary files not expected for Nano V9!"
+    exit 1
+fi
+
+config_name=configs/${name}_cfg.py
+outfile=${name}.root
+
+cmsDriver.py RECO --conditions 106X_upgrade2018_realistic_v16_L1v1 \
+    --datatier NANOAODSIM --eventcontent NANOAODSIM \
+    --era Run2_2018,run2_nanoAOD_106Xv2 \
+    --geometry DB:Extended \
+    --customise Configuration/DataProcessing/Utils.addMonitoring, PhysicsTools/NanoAOD/nanoTP_cff.customizeNANOTP \
+    --filein $sample_name --fileout file:$outfile --nThreads $nThreads --no_exec \
+    --python_filename $config_name --mc \
+    --scenario pp --step PAT,USERNANO:nanotpSequenceMC \
+    --runUnscheduled -n $nevents 
+

--- a/scripts/prepareCrab.py
+++ b/scripts/prepareCrab.py
@@ -19,22 +19,21 @@ def fillTemplatedFile(template_file_name, out_file_name, template_dict):
     with open(out_file_name, "w") as outFile:
         outFile.write(result)
 
-def nameFromInput(das_path, tagAndProbe=False):
+def nameFromInput(das_path, tagAndProbe=False):    
     label = "MC" if "SIM" in das_path[-3:] else "Data"
     if 'UL2017' in das_path or 'UL17' in das_path: #needed since pattern in data and MC names are different
         label += '2017'
-        return label
     elif 'UL2018' in das_path or 'UL18' in das_path:
         label += '2018'
-        return label
     if tagAndProbe:
         label += "TagAndProbe"
-    if 'Data' in label:
+
+    if 'Data' in label and 'UL2016' in das_path:
         if 'HIPM' in das_path: 
             label += "PreVFP"
         else: 
             label += "PostVFP"
-    else:#for MC
+    elif 'UL16' in das_path:#for MC 2016
         # TODO: This doesn't actually work for data!
         label += "PreVFP" if "APV" in das_path else "PostVFP"
 


### PR DESCRIPTION

Added MC datasets and shell scripts for generating the T&P MC configs. 
To produce the configs for T&P, 
```./scripts/prepareCrab.py --makeConfig -j1 -i inputs/dy2018_TnP_v9.txt   --tagAndProbe```